### PR TITLE
Bookmarked courses will now move under a 'saved courses' section

### DIFF
--- a/frontend/src/components/SearchCards.tsx
+++ b/frontend/src/components/SearchCards.tsx
@@ -57,7 +57,6 @@ export default function SearchCards() {
     }
   };
 
-  // todo: move bookmarked courses into a "saved courses" area
   const handleBookmarkClick = (courseToBookmark: any) => {
     if (courseToBookmark.id in bookmarkedCourses) {
       const newBookmarks = { ...bookmarkedCourses };
@@ -71,137 +70,170 @@ export default function SearchCards() {
     }
   };
 
+  const renderBookmarkedCourses = () => {
+    if (Object.keys(bookmarkedCourses).length !== 0) {
+      return (
+        <div>
+          <Typography>Saved Courses</Typography>
+          <>
+            {Object.values(bookmarkedCourses).map((course, i) => {
+              return createCourseCard(course, i);
+            })}
+          </>
+        </div>
+      );
+    } else {
+      return false;
+    }
+  };
+
+  const createCourseCard = (course: any, i: number) => {
+    return (
+      <Card style={{ marginTop: "20px" }} elevation={2} key={i}>
+        <CardContent>
+          {/* TOP BAR (CONDENSED INFO) */}
+          <Stack
+            direction="row"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <Tooltip
+              title={
+                course.id in bookmarkedCourses
+                  ? "Unpin Course"
+                  : "Pin Course to Search Results"
+              }
+              enterNextDelay={1000}
+              arrow
+            >
+              <IconButton
+                aria-label="expand more"
+                style={{
+                  padding: "0px",
+                  margin: "0px 8px 0px 0px",
+                }}
+                onClick={() => handleBookmarkClick(course)}
+              >
+                {course.id in bookmarkedCourses ? (
+                  <BookmarkIcon />
+                ) : (
+                  <BookmarkBorderIcon />
+                )}
+              </IconButton>
+            </Tooltip>
+            {/* todo: conditional styling for very long course names ex. CS 146*/}
+            <Typography variant="subtitle1" style={{ fontWeight: "bold" }}>
+              {course.department}
+              {course.code} - {course.name}
+            </Typography>
+            <div style={{ marginLeft: "auto", marginRight: "0px" }}>
+              <Tooltip title="Add Course to Calendar" arrow>
+                <IconButton aria-label="add course">
+                  <AddCircleIcon />
+                </IconButton>
+              </Tooltip>
+              <IconButton
+                aria-label="expand more"
+                onClick={() => handleExpandClick(course)}
+              >
+                {expandedCard === course.id ? (
+                  <ExpandLessIcon />
+                ) : (
+                  <ExpandMoreIcon />
+                )}
+              </IconButton>
+            </div>
+          </Stack>
+          {/* BODY CONTENT (EXPANDED INFO) */}
+          <Collapse in={expandedCard === course.id ? true : false}>
+            <Typography variant="body2">{course.description}</Typography>
+            <br />
+            {/* COURSE INFO TABLE */}
+            <TableContainer component={Paper}>
+              <Table aria-label="simple table" size="small">
+                <TableHead>
+                  <TableRow>
+                    <StyledTableCell>Section</StyledTableCell>
+                    <StyledTableCell>Class</StyledTableCell>
+                    <StyledTableCell>Enrolled</StyledTableCell>
+                    <StyledTableCell>Time</StyledTableCell>
+                    <StyledTableCell>Date</StyledTableCell>
+                    <StyledTableCell>Location</StyledTableCell>
+                    <StyledTableCell>Instructor</StyledTableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {course.sections.map((section: any) => {
+                    // Format days of the week courses are held (TUESDAY, THURSDAY, FRIDAY -> T, TH, F)
+                    let days = "";
+                    for (let i = 0; i < section.day.length; i++) {
+                      if (section.day[i].slice(0, 2) === "TH") {
+                        days = days.concat(section.day[i].slice(0, 2));
+                      } else {
+                        days = days.concat(section.day[i].slice(0, 1));
+                      }
+                      if (i < section.day.length - 1) {
+                        days = days.concat(", ");
+                      }
+                    }
+                    return (
+                      <TableRow
+                        key={section.class_number}
+                        sx={{
+                          "&:last-child td, &:last-child th": { border: 0 },
+                        }}
+                      >
+                        <StyledTableCell component="th" scope="row">
+                          {section.type.slice(0, 3)} {section.number}
+                        </StyledTableCell>
+                        <StyledTableCell>
+                          {section.class_number}
+                        </StyledTableCell>
+                        <StyledTableCell>
+                          {section.enrolled_number}/{section.capacity}
+                        </StyledTableCell>
+                        <StyledTableCell>
+                          {moment
+                            .utc()
+                            .startOf("day")
+                            .add(section.start_time, "minutes")
+                            .format("hh:mm A")}
+                          {" - "}
+                          {moment
+                            .utc()
+                            .startOf("day")
+                            .add(section.end_time, "minutes")
+                            .format("hh:mm A")}
+                        </StyledTableCell>
+                        <StyledTableCell>{days}</StyledTableCell>
+                        <StyledTableCell>{section.location}</StyledTableCell>
+                        {/* todo: add instructor info */}
+                        <StyledTableCell>N/A</StyledTableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+            {/* todo: add prereq and antireq info */}
+          </Collapse>
+        </CardContent>
+      </Card>
+    );
+  };
+
   return (
     <Box>
       {/* todo: clean up styles */}
       {/* todo: proper call to get courses */}
-      {courses.map((course, i) => (
-        <Card style={{ marginTop: "20px" }} elevation={2} key={i}>
-          <CardContent>
-            {/* TOP BAR (CONDENSED INFO) */}
-            <Stack
-              direction="row"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                flexWrap: "wrap",
-              }}
-            >
-              <Tooltip title="Pin Course to Search Results" arrow>
-                <IconButton
-                  aria-label="expand more"
-                  style={{
-                    padding: "0px",
-                    margin: "0px 8px 0px 0px",
-                  }}
-                  onClick={() => handleBookmarkClick(course)}
-                >
-                  {course.id in bookmarkedCourses ? (
-                    <BookmarkIcon />
-                  ) : (
-                    <BookmarkBorderIcon />
-                  )}
-                </IconButton>
-              </Tooltip>
-              {/* todo: conditional styling for very long course names ex. CS 146*/}
-              <Typography variant="subtitle1" style={{ fontWeight: "bold" }}>
-                {course.department}
-                {course.code} - {course.name}
-              </Typography>
-              <div style={{ marginLeft: "auto", marginRight: "0px" }}>
-                <Tooltip title="Add Course to Calendar" arrow>
-                  <IconButton aria-label="add course">
-                    <AddCircleIcon />
-                  </IconButton>
-                </Tooltip>
-                <IconButton
-                  aria-label="expand more"
-                  onClick={() => handleExpandClick(course)}
-                >
-                  {expandedCard === course.id ? (
-                    <ExpandLessIcon />
-                  ) : (
-                    <ExpandMoreIcon />
-                  )}
-                </IconButton>
-              </div>
-            </Stack>
-            {/* BODY CONTENT (EXPANDED INFO) */}
-            <Collapse in={expandedCard === course.id ? true : false}>
-              <Typography variant="body2">{course.description}</Typography>
-              <br />
-              {/* COURSE INFO TABLE */}
-              <TableContainer component={Paper}>
-                <Table aria-label="simple table" size="small">
-                  <TableHead>
-                    <TableRow>
-                      <StyledTableCell>Section</StyledTableCell>
-                      <StyledTableCell>Class</StyledTableCell>
-                      <StyledTableCell>Enrolled</StyledTableCell>
-                      <StyledTableCell>Time</StyledTableCell>
-                      <StyledTableCell>Date</StyledTableCell>
-                      <StyledTableCell>Location</StyledTableCell>
-                      <StyledTableCell>Instructor</StyledTableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {course.sections.map((section) => {
-                      // Format days of the week courses are held (TUESDAY, THURSDAY, FRIDAY -> T, TH, F)
-                      let days = "";
-                      for (let i = 0; i < section.day.length; i++) {
-                        if (section.day[i].slice(0, 2) === "TH") {
-                          days = days.concat(section.day[i].slice(0, 2));
-                        } else {
-                          days = days.concat(section.day[i].slice(0, 1));
-                        }
-                        if (i < section.day.length - 1) {
-                          days = days.concat(", ");
-                        }
-                      }
-                      return (
-                        <TableRow
-                          key={section.class_number}
-                          sx={{
-                            "&:last-child td, &:last-child th": { border: 0 },
-                          }}
-                        >
-                          <StyledTableCell component="th" scope="row">
-                            {section.type.slice(0, 3)} {section.number}
-                          </StyledTableCell>
-                          <StyledTableCell>
-                            {section.class_number}
-                          </StyledTableCell>
-                          <StyledTableCell>
-                            {section.enrolled_number}/{section.capacity}
-                          </StyledTableCell>
-                          <StyledTableCell>
-                            {moment
-                              .utc()
-                              .startOf("day")
-                              .add(section.start_time, "minutes")
-                              .format("hh:mm A")}
-                            {" - "}
-                            {moment
-                              .utc()
-                              .startOf("day")
-                              .add(section.end_time, "minutes")
-                              .format("hh:mm A")}
-                          </StyledTableCell>
-                          <StyledTableCell>{days}</StyledTableCell>
-                          <StyledTableCell>{section.location}</StyledTableCell>
-                          {/* todo: add instructor info */}
-                          <StyledTableCell>N/A</StyledTableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-              {/* todo: add prereq and antireq info */}
-            </Collapse>
-          </CardContent>
-        </Card>
-      ))}
+      {renderBookmarkedCourses()}
+      <Typography>Search Results</Typography>
+      {courses
+        .filter((course) => (course.id in bookmarkedCourses ? false : true))
+        .map((course, i) => createCourseCard(course, i))}
     </Box>
   );
 }


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- when users bookmark a course it will be stickied to the top of the search results panel under the "Saved Courses" heading
- and they can also un-bookmark it
- moved card rendering block into it's own function that is called for both bookmarked course cards and search result cards

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. "Saved Courses" should only appear when there is at least one bookmarked course
2. If a course is bookmarked it should no longer show in the search results list
3. If unbookmarked it should re-appear in the search results

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-
