### PR TITLE
Add support for bulk editing course colors

### DIFF
--- a/backend/app/routes/schedule_routes.py
+++ b/backend/app/routes/schedule_routes.py
@@ -21,8 +21,24 @@ def schedule_courses_by_user(curr_user):
             )
         elif request.method == "PUT":
             request_data = request.get_json()
-            uid = request_data["uid"]
             color = request_data["color"]
+            uid = request_data.get("uid", None)
+            course_id = request_data.get("course_id", None)
+            if uid:
+                result = schedule_service.update_schedule_color_by_user(
+                    curr_user, uid, color
+                )
+            elif course_id:
+                result = schedule_service.update_schedule_colors_by_user(
+                    curr_user, course_id, color
+                )
+            else:
+                return (
+                    jsonify(
+                        {"error": "At least one of course id or uid must be specified"}
+                    ),
+                    400,
+                )
             result = schedule_service.update_schedule_color_by_user(
                 curr_user, uid, color
             )
@@ -68,9 +84,22 @@ def schedule_courses_by_id(id):
             result = schedule_service.add_courses_to_schedule_by_id(id, courses)
         elif request.method == "PUT":
             request_data = request.get_json()
-            uid = request_data["uid"]
             color = request_data["color"]
-            result = schedule_service.update_schedule_color_by_id(id, uid, color)
+            uid = request_data.get("uid", None)
+            course_id = request_data.get("course_id", None)
+            if uid:
+                result = schedule_service.update_schedule_color_by_id(id, uid, color)
+            elif course_id:
+                result = schedule_service.update_schedule_colors_by_id(
+                    id, course_id, color
+                )
+            else:
+                return (
+                    jsonify(
+                        {"error": "At least one of course id or uid must be specified"}
+                    ),
+                    400,
+                )
         else:
             raise Exception(f"Unsupported method {request.method}")
         return jsonify(result), 200


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- add support for editing colors for all courses on schedule (per #75)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Try to update by course_id
```bash
curl -X PUT -H "Content-Type: application/json" -d '{"course_id": "64126c77269911f00d6f2500", "color": "#acabae"}' localhost:5000/schedules/64127ede93deee8bdc7a9121
```
2. Try to update by uid (sanity check)
```bash
curl -X PUT -H "Content-Type: application/json" -d '{"uid": "641774dd7286622ffdf31c20", "color": "##dcabae"}' localhost:5000/schedules/64127ede93deee8bdc7a9121      
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-
